### PR TITLE
Fix tnoremap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ nnoremap <silent> <F4> :call vimterm#exec('g++  -o /tmp/out' . expand('%')) <CR>
 nnoremap <silent> <F5> :call vimterm#exec('/tmp/out') <CR>
 
 nnoremap <F7> :call vimterm#toggle() <CR>
-tnoremap <F7> :call vimterm#toggle() <CR>
+tnoremap <F7> <C-\><C-n>:call vimterm#toggle() <CR>
 ```
 
 ## installation


### PR DESCRIPTION
Add command to get input focus back to neovim from terminal before calling vimterm#toggle().