### PR TITLE
Silence buffer info

### DIFF
--- a/autoload/vimterm.vim
+++ b/autoload/vimterm.vim
@@ -15,7 +15,7 @@ function! vimterm#open()
       execute 'resize ' . g:vimterm_height
       let s:vimterm_window = win_getid()
     endif
-    exec 'buffer ' . s:vimterm_buf
+    exec 'silent buffer ' . s:vimterm_buf
     startinsert
   endif
 endfunction


### PR DESCRIPTION
The `:buffer` command apparently has the effect of producing a message like `:file`, such as
```
"term://.//1014:/bin/bash" 17 lines --5%--
```
This makes it silent.